### PR TITLE
Only handle grant if menu isn't visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ const Menu = class extends React.Component {
 
             // Initially, set the value of x to 0 (the center of the screen)
             onPanResponderGrant: (e, gestureState) => {
-                if (!this.granted){
+                if (!this.granted && !this.state.isVisible){
                     this.granted = true;
                     // Set the initial value to the current state
                     this.state.pan.setOffset(this.state.pan._value);


### PR DESCRIPTION
@kyle-ssg Fixes an issue where if a component within the drawer takes over as pan responder, on release the menu will be granted access again causing it to reset its state as if it were closed but it will remain open indefinitely.